### PR TITLE
don't do any work on --help option

### DIFF
--- a/bin/text-vimcolor
+++ b/bin/text-vimcolor
@@ -56,6 +56,7 @@ if ($usage) {
       "                 don't include the stylesheet in a complete HTML page\n",
       "    --let        set a Vim variable with the Vim :let command\n",
       "    --unlet      turn off default setting of a Vim variable\n";
+    exit 0;
 }
 
 defined $format


### PR DESCRIPTION
This is more consistent with other command-line utils and won't confuse
users which are not accustomed to the script (previous version waited
for stdin to be closed on --help).
